### PR TITLE
Finalizing zscp

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -13,14 +13,20 @@ jobs:
       matrix:
         include:
          - os: ubuntu-latest
-           artifact_name: zssh
-           asset_name: zssh-linux-amd64
+           zssh_artifact_name: zssh
+           zssh_asset_name: zssh-linux-amd64
+           zscp_artifact_name: zscp
+           zscp_asset_name: zscp-linux-amd64
          - os: windows-latest
-           artifact_name: zssh.exe
-           asset_name: zssh-windows-amd64.exe
+           zssh_artifact_name: zssh.exe
+           zssh_asset_name: zssh-windows-amd64.exe
+           zscp_artifact_name: zscp.exe
+           zscp_asset_name: zscp-windows-amd64.exe
          - os: macos-latest
-           artifact_name: zssh
-           asset_name: zssh-macos-amd64
+           zssh_artifact_name: zssh
+           zssh_asset_name: zssh-macos-amd64
+           zscp_artifact_name: zscp
+           zscp_asset_name: zscp-macos-amd64
     steps:
     - uses: actions/checkout@v2
 
@@ -33,22 +39,20 @@ jobs:
       run: mkdir "${{ runner.workspace }}/build"
       
     - name: Build
-      run: go build -o ${{ runner.workspace }}/build ./... 
+      run: go build -o ${{ runner.workspace }}/build ./...
 
-    - name: Upload binaries to release
+    - name: Upload zssh binaries to release
       uses: svenstaro/upload-release-action@v2
       with:
         repo_token: ${{ secrets.GITHUB_TOKEN }}
-        file: ${{ runner.workspace }}/build/${{ matrix.artifact_name }}
-        asset_name: ${{ matrix.asset_name }}
-        tag: latest-tag
-        overwrite: true
-        release_name: latest-tagged-release
-        
-    - name: Upload binaries to release
+        file: ${{ runner.workspace }}/build/${{ matrix.zssh_artifact_name }}
+        asset_name: ${{ matrix.zssh_asset_name }}
+        tag: ${{ github.ref }}
+
+    - name: Upload zscp binaries to release
       uses: svenstaro/upload-release-action@v2
       with:
         repo_token: ${{ secrets.GITHUB_TOKEN }}
-        file: ${{ runner.workspace }}/build/${{ matrix.artifact_name }}
-        asset_name: ${{ matrix.asset_name }}
+        file: ${{ runner.workspace }}/build/${{ matrix.zscp_artifact_name }}
+        asset_name: ${{ matrix.zscp_asset_name }}
         tag: ${{ github.ref }}

--- a/zssh/zscp/main.go
+++ b/zssh/zscp/main.go
@@ -33,37 +33,42 @@ const ExpectedServiceAndExeName = "zssh"
 var flags = &zsshlib.ScpFlags{}
 var rootCmd = &cobra.Command{
 	Use: "Remote to Local: zscp <remoteUsername>@<targetIdentity>:[Remote Path] [Local Path]\n" +
-		"Local to Remote: zscp [Local Path] <remoteUsername>@<targetIdentity>:[Remote Path]",
+		"Local to Remote: zscp [Local Path][...] <remoteUsername>@<targetIdentity>:[Remote Path]",
 	Short: "Z(iti)scp, Carb-loaded ssh performs faster and stronger than ssh",
 	Long:  "Z(iti)scp is a version of ssh that utilizes a ziti network to provide a faster and more secure remote connection. A ziti connection must be established before use",
-	Args:  cobra.ExactValidArgs(2),
+	Args:  cobra.MinimumNArgs(2),
 	Run: func(cmd *cobra.Command, args []string) {
 		var remoteFilePath string
-		var localFilePath string
+		var localFilePaths[] string
 		var isCopyToRemote bool
+		var err error
 
 		if strings.ContainsAny(args[0], ":") {
 			remoteFilePath = args[0]
-			localFilePath = args[1]
+			localFilePaths = args[1:]
+			if len(localFilePaths) > 1 {
+				logrus.Fatalf("remote to local cannot have more than two arguments")
+			}
 			isCopyToRemote = false
 
-		} else if strings.ContainsAny(args[1], ":") {
-			remoteFilePath = args[1]
-			localFilePath = args[0]
+		} else if strings.ContainsAny(args[len(args)-1], ":") {
+			remoteFilePath = args[len(args)-1]
+			localFilePaths = args[0:len(args)-1]
 			isCopyToRemote = true
 		} else {
 			logrus.Fatal(`cannot determine remote file PATH use ":" for remote path`)
 		}
 
-		localFilePath, err := filepath.Abs(localFilePath)
-		if err != nil {
-			logrus.Fatalf("cannot determine absolute local file path, unrecognized file name: %s", localFilePath)
+		for i, path := range localFilePaths {
+			localFilePaths[i], err = filepath.Abs(path)
+			if err != nil {
+				logrus.Fatalf("cannot determine absolute local file path, unrecognized file name: %s", path)
+			}
+			if _, err := os.Stat(localFilePaths[i]); err != nil {
+				logrus.Fatal(err)
+			}
+			flags.DebugLog("           local path: %s", localFilePaths[i])
 		}
-		if _, err := os.Stat(localFilePath); err != nil {
-			logrus.Fatal(err)
-		}
-
-		flags.DebugLog("           local path: %s", localFilePath)
 
 		username, targetIdentity := flags.GetUserAndIdentity(remoteFilePath)
 		remoteFilePath = zsshlib.ParseFilePath(remoteFilePath)
@@ -77,74 +82,86 @@ var rootCmd = &cobra.Command{
 		}
 		defer func() { _ = client.Close() }()
 
-		if remoteFilePath == "~" {
-			remoteFilePath = ""
-		} else if strings.HasPrefix(remoteFilePath,"~/") {
-			remoteFilePath = after(remoteFilePath, "~/")
+		remoteFilePath, err = client.RealPath(remoteFilePath)
+		if err != nil{
+			logrus.Fatalf("cannot find remote file path: %s [%v]", remoteFilePath, err)
 		}
 
+		remoteGlob, err := client.Glob(remoteFilePath)
+		if err != nil {
+			logrus.Fatalf("file pattern [%s] not recognized [%v]", remoteFilePath, err)
+		} else if remoteGlob == nil {
+			remoteGlob = append(remoteGlob, remoteFilePath)
+		}
 
-		if isCopyToRemote {
-			if flags.Recursive {
-				baseDir := filepath.Base(localFilePath)
-				err := filepath.WalkDir(localFilePath, func(path string, info fs.DirEntry, err error) error {
-					remotePath := filepath.Join(remoteFilePath, baseDir, after(path, baseDir))
-					if info.IsDir() {
-						err = client.Mkdir(remotePath)
-						if err != nil {
-							flags.DebugLog("%s", err) //occurs when directories exist already. Is not fatal. Only logs when debug flag is set.
+		if isCopyToRemote { //local to remote
+			for i, localFilePath := range localFilePaths {
+				if flags.Recursive {
+					baseDir := filepath.Base(localFilePath)
+					err := filepath.WalkDir(localFilePath, func(path string, info fs.DirEntry, err error) error {
+						remotePath := filepath.Join(remoteFilePath, baseDir, after(path, baseDir))
+						if info.IsDir() {
+							err = client.Mkdir(remotePath)
+							if err != nil {
+								flags.DebugLog("%s", err) //occurs when directories exist already. Is not fatal. Only logs when debug flag is set.
+							} else {
+								flags.DebugLog("made directory: %s", remotePath)
+							}
 						} else {
-							flags.DebugLog("made directory: %s", remotePath)
+							err = zsshlib.SendFile(client, path, remotePath)
+							if err != nil {
+								return fmt.Errorf("could not send file: %s [%v]", path, err)
+							} else {
+								logrus.Infof("sent file: %s ==> %s", path, remotePath)
+							}
 						}
-					} else {
-						err = zsshlib.SendFile(client, path, remotePath)
-						if err != nil {
-							return fmt.Errorf("could not send file: %s [%v]", path, err)
-						} else {
-							logrus.Infof("sent file: %s ==> %s", path, remotePath)
-						}
+						return nil
+					})
+					if err != nil {
+						logrus.Fatal(err)
 					}
-					return nil
-				})
-				if err != nil {
-					logrus.Fatal(err)
-				}
-			} else {
-				remoteFilePath = zsshlib.AppendBaseName(client, remoteFilePath, localFilePath, flags.Debug)
-				err = zsshlib.SendFile(client, localFilePath, remoteFilePath)
-				if err != nil {
-					logrus.Errorf("could not send file: %s [%v]", localFilePath, err)
 				} else {
-					logrus.Infof("sent file: %s ==> %s", localFilePath, remoteFilePath)
+					if i > 0 {
+						remoteFilePath = filepath.Join(filepath.Dir(remoteFilePath), filepath.Base(localFilePath))
+					}
+					remoteFilePath = zsshlib.AppendBaseName(client, remoteFilePath, localFilePath, flags.Debug)
+					err = zsshlib.SendFile(client, localFilePath, remoteFilePath)
+					if err != nil {
+						logrus.Errorf("could not send file: %s [%v]", localFilePath, err)
+					} else {
+						logrus.Infof("sent file: %s ==> %s", localFilePath, remoteFilePath)
+					}
 				}
 			}
-		} else {
+		} else { //remote to local
+			for _, remoteFilePath = range remoteGlob {
 			if flags.Recursive {
-				baseDir := filepath.Base(remoteFilePath)
-				walker := client.Walk(remoteFilePath)
-				for walker.Step() {
-					localPath := filepath.Join(localFilePath, baseDir, after(walker.Path(), baseDir))
-					if walker.Stat().IsDir() {
-						err = os.Mkdir(localPath, os.ModePerm)
-						if err != nil {
-							flags.DebugLog("failed to make directory: %s [%v]", localPath, err) //occurs when directories exist already. Is not fatal. Only logs when debug flag is set.
+					baseDir := filepath.Base(remoteFilePath)
+					walker := client.Walk(remoteFilePath)
+					for walker.Step() {
+						localPath := filepath.Join(localFilePaths[0], baseDir, after(walker.Path(), baseDir)) //saves base directory to cut remote directory after it to append to localpath
+						if walker.Stat().IsDir() {
+							err = os.Mkdir(localPath, os.ModePerm)
+							if err != nil {
+								flags.DebugLog("failed to make directory: %s [%v]", localPath, err) //occurs when directories exist already. Is not fatal. Only logs when debug flag is set.
+							} else {
+								flags.DebugLog("made directory: %s", localPath)
+							}
 						} else {
-							flags.DebugLog("made directory: %s", localPath)
-						}
-					} else {
-						err = zsshlib.RetrieveRemoteFiles(client, localPath, walker.Path())
-						if err != nil {
-							logrus.Fatalf("failed to retrieve file: %s [%v]", walker.Path(), err)
+							err = zsshlib.RetrieveRemoteFiles(client, localPath, walker.Path())
+							if err != nil {
+								logrus.Fatalf("failed to retrieve file: %s [%v]", walker.Path(), err)
+							}
 						}
 					}
-				}
-			} else {
-				if info, _ := os.Lstat(localFilePath); info.IsDir() {
-					localFilePath = filepath.Join(localFilePath, filepath.Base(remoteFilePath))
-				}
-				err = zsshlib.RetrieveRemoteFiles(client, localFilePath, remoteFilePath)
-				if err != nil {
-					logrus.Fatalf("failed to retrieve file: %s [%v]", remoteFilePath, err)
+				} else {
+					if info, _ := os.Lstat(localFilePaths[0]); info.IsDir() {
+						localFilePaths[0] = filepath.Join(localFilePaths[0], filepath.Base(remoteFilePath))
+					}
+					err = zsshlib.RetrieveRemoteFiles(client, localFilePaths[0], remoteFilePath)
+					if err != nil {
+						logrus.Fatalf("failed to retrieve file: %s [%v]", remoteFilePath, err)
+					}
 				}
 			}
 		}

--- a/zssh/zscp/main.go
+++ b/zssh/zscp/main.go
@@ -84,7 +84,7 @@ var rootCmd = &cobra.Command{
 
 		if remoteFilePath == "~" {
 			remoteFilePath = ""
-		} else if remoteFilePath[:2] == "~/" {
+		} else if len(remoteFilePath) > 1 && remoteFilePath[:2] == "~/" {
 			remoteFilePath = after(remoteFilePath, "~/")
 		}
 
@@ -140,12 +140,13 @@ var rootCmd = &cobra.Command{
 				}
 			}
 		} else { //remote to local
+			localFilePath := localFilePaths[0]
 			for _, remoteFilePath = range remoteGlob {
 				if flags.Recursive {
 					baseDir := filepath.Base(remoteFilePath)
 					walker := client.Walk(remoteFilePath)
 					for walker.Step() {
-						localPath := filepath.Join(localFilePaths[0], baseDir, after(walker.Path(), baseDir)) //saves base directory to cut remote directory after it to append to localpath
+						localPath := filepath.Join(localFilePath, baseDir, after(walker.Path(), baseDir)) //saves base directory to cut remote directory after it to append to localpath
 						if walker.Stat().IsDir() {
 							err = os.Mkdir(localPath, os.ModePerm)
 							if err != nil {
@@ -162,9 +163,9 @@ var rootCmd = &cobra.Command{
 					}
 				} else {
 					if info, _ := os.Lstat(localFilePaths[0]); info.IsDir() {
-						localFilePaths[0] = filepath.Join(localFilePaths[0], filepath.Base(remoteFilePath))
+						localFilePath = filepath.Join(localFilePaths[0], filepath.Base(remoteFilePath))
 					}
-					err = zsshlib.RetrieveRemoteFiles(client, localFilePaths[0], remoteFilePath)
+					err = zsshlib.RetrieveRemoteFiles(client, localFilePath, remoteFilePath)
 					if err != nil {
 						logrus.Fatalf("failed to retrieve file: %s [%v]", remoteFilePath, err)
 					}

--- a/zssh/zscp/main.go
+++ b/zssh/zscp/main.go
@@ -39,7 +39,7 @@ var rootCmd = &cobra.Command{
 	Args:  cobra.MinimumNArgs(2),
 	Run: func(cmd *cobra.Command, args []string) {
 		var remoteFilePath string
-		var localFilePaths[] string
+		var localFilePaths []string
 		var isCopyToRemote bool
 		var err error
 
@@ -53,7 +53,7 @@ var rootCmd = &cobra.Command{
 
 		} else if strings.ContainsAny(args[len(args)-1], ":") {
 			remoteFilePath = args[len(args)-1]
-			localFilePaths = args[0:len(args)-1]
+			localFilePaths = args[0 : len(args)-1]
 			isCopyToRemote = true
 		} else {
 			logrus.Fatal(`cannot determine remote file PATH use ":" for remote path`)
@@ -82,8 +82,14 @@ var rootCmd = &cobra.Command{
 		}
 		defer func() { _ = client.Close() }()
 
+		if remoteFilePath == "~" {
+			remoteFilePath = ""
+		} else if remoteFilePath[:2] == "~/" {
+			remoteFilePath = after(remoteFilePath, "~/")
+		}
+
 		remoteFilePath, err = client.RealPath(remoteFilePath)
-		if err != nil{
+		if err != nil {
 			logrus.Fatalf("cannot find remote file path: %s [%v]", remoteFilePath, err)
 		}
 
@@ -135,7 +141,7 @@ var rootCmd = &cobra.Command{
 			}
 		} else { //remote to local
 			for _, remoteFilePath = range remoteGlob {
-			if flags.Recursive {
+				if flags.Recursive {
 					baseDir := filepath.Base(remoteFilePath)
 					walker := client.Walk(remoteFilePath)
 					for walker.Step() {

--- a/zsshlib/ssh.go
+++ b/zsshlib/ssh.go
@@ -214,7 +214,7 @@ func RetrieveRemoteFiles(client *sftp.Client, localPath string, remotePath strin
 
 	lf, err := os.OpenFile(localPath, os.O_WRONLY|os.O_CREATE|os.O_TRUNC, os.ModePerm)
 	if err != nil {
-		return fmt.Errorf("error opening local file [%s] (%w)", remotePath, err)
+		return fmt.Errorf("error opening local file [%s] (%w)", localPath, err)
 	}
 	defer func() { _ = lf.Close() }()
 


### PR DESCRIPTION
Tested and working consistently in all use cases. Currently as same functionality as scp but with identity name argument instead of IP. 

Working use cases:
local to remote single file transfer with assumed name or changed name.
remote to local single file transfer with assumed name or changed name.
Recursive local to remote multiple file transfer with assumed directory name (cannot change directory name in process)
Recursive remote to local multiple file transfer with assumed directory name (cannot change directory name in process)
relative path indicators for local path for both to and from transfer: { . , .. , / , ~)
wild card/glob (*) capability for both local and remote paths for both filenames and directory names (recursive copy)

Note: this PR is intended for use case functionality. Improving logs and tests will be apart of next PR to main.

