### PR TITLE
attempt to support a config file keyed by target identity

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -1,0 +1,113 @@
+package config
+
+import (
+	"github.com/sirupsen/logrus"
+	"os"
+	"path/filepath"
+
+	"gopkg.in/yaml.v2"
+)
+
+type OIDC struct {
+	CallbackPort string `yaml:"callback_port"`
+	ClientID     string `yaml:"client_id"`
+	ClientSecret string `yaml:"client_secret"`
+	Issuer       string `yaml:"issuer"`
+	Enabled      bool   `yaml:"enabled"`
+}
+
+type Config struct {
+	SshKeyPath string `yaml:"ssh_key_path"`
+	ZConfig    string `yaml:"zconfig"`
+	Debug      bool   `yaml:"debug"`
+	Service    string `yaml:"service"`
+	OIDC       OIDC   `yaml:"oidc"`
+	Username   string `yaml:"user"`
+}
+
+type ConfigMap map[string]Config
+
+func ConfigHome() string {
+	configHome := os.Getenv("XDG_CONFIG_HOME")
+	if configHome == "" {
+		configHome = filepath.Join(os.Getenv("HOME"), ".config")
+	}
+	return configHome
+}
+
+// GetConfigFilePath returns the path to the config file in the ~/.config directory.
+func GetConfigFilePath() string {
+	return filepath.Join(ConfigHome(), "zssh", "config.yaml")
+}
+
+// DefaultIdentityFile returns the path to the config file in the ~/.config directory.
+func DefaultIdentityFile() string {
+	return filepath.Join(ConfigHome(), "zssh", "default.json")
+}
+
+// LoadConfigs loads the configuration array from a YAML file.
+func LoadConfigs(filePath string) (ConfigMap, error) {
+	file, err := os.ReadFile(filePath)
+	if err != nil {
+		return nil, err
+	}
+
+	var configs ConfigMap
+	if err := yaml.Unmarshal(file, &configs); err != nil {
+		return nil, err
+	}
+
+	return configs, nil
+}
+
+// SaveConfigs saves the configuration array to a YAML file.
+func SaveConfigs(configs []Config, filePath string) error {
+	data, err := yaml.Marshal(configs)
+	if err != nil {
+		return err
+	}
+
+	if err := os.WriteFile(filePath, data, 0644); err != nil {
+		return err
+	}
+
+	return nil
+}
+
+// DefaultConfig returns a default configuration.
+func DefaultConfig() *Config {
+	return &Config{
+		SshKeyPath: filepath.Join(os.Getenv("HOME"), ".ssh", "id_rsa"),
+		ZConfig:    filepath.Join(os.Getenv("HOME"), ".ziti", "zssh.json"),
+		Debug:      false,
+		Service:    "zssh",
+		OIDC: OIDC{
+			CallbackPort: "63275",
+			ClientID:     "cid1",
+			ClientSecret: "",
+			Issuer:       "https://dev-yourid.okta.com",
+			Enabled:      false,
+		},
+	}
+}
+
+// FindConfigByKey finds a configuration by the targetIdentity/key
+func FindConfigByKey(key string) *Config {
+	configs := LoadConfigFile()
+	if cfg, exists := configs[key]; exists {
+		return &cfg
+	}
+	return DefaultConfig()
+}
+
+func LoadConfigFile() ConfigMap {
+	configFilePath := GetConfigFilePath()
+	// Load the configurations from the file, or use defaults if the file doesn't exist
+	configs, err := LoadConfigs(configFilePath)
+	if err != nil {
+		if !os.IsNotExist(err) {
+			logrus.Fatalf("Error loading config: %v", err)
+		}
+	}
+	return configs
+}

--- a/go.mod
+++ b/go.mod
@@ -17,6 +17,7 @@ require (
 	github.com/zitadel/oidc/v2 v2.12.0
 	golang.org/x/crypto v0.25.0
 	golang.org/x/oauth2 v0.21.0
+	gopkg.in/yaml.v2 v2.4.0
 )
 
 require (

--- a/zssh/zscp/main.go
+++ b/zssh/zscp/main.go
@@ -28,6 +28,7 @@ import (
 	"os"
 	"path/filepath"
 	"strings"
+	"zssh/config"
 	"zssh/zsshlib"
 )
 
@@ -81,10 +82,13 @@ var rootCmd = &cobra.Command{
 			flags.DebugLog("           local path: %s", localFilePaths[i])
 		}
 
-		username, targetIdentity := flags.GetUserAndIdentity(remoteFilePath)
+		targetIdentity := zsshlib.ParseTargetIdentity(remoteFilePath)
+		cfg := config.FindConfigByKey(targetIdentity)
+		zsshlib.Combine(cmd, &flags.SshFlags, cfg)
+
 		remoteFilePath = zsshlib.ParseFilePath(remoteFilePath)
 
-		sshConn := zsshlib.EstablishClient(flags.SshFlags, username, targetIdentity, token)
+		sshConn := zsshlib.EstablishClient(flags.SshFlags, remoteFilePath, targetIdentity, token)
 		defer func() { _ = sshConn.Close() }()
 
 		client, err := sftp.NewClient(sshConn)

--- a/zssh/zssh/main.go
+++ b/zssh/zssh/main.go
@@ -20,6 +20,7 @@ import (
 	"context"
 	"fmt"
 	"os"
+	"zssh/config"
 	"zssh/zsshlib"
 
 	"github.com/openziti/ziti/common/enrollment"
@@ -45,7 +46,9 @@ var rootCmd = &cobra.Command{
 			os.Exit(1)
 		}
 
-		username, targetIdentity := flags.GetUserAndIdentity(args[0])
+		targetIdentity := zsshlib.ParseTargetIdentity(args[0])
+		cfg := config.FindConfigByKey(targetIdentity)
+		zsshlib.Combine(cmd, &flags, cfg)
 
 		cmdArgs := args[1:]
 		token := ""
@@ -56,7 +59,7 @@ var rootCmd = &cobra.Command{
 				logrus.Fatalf("error performing OIDC flow: %v", err)
 			}
 		}
-		sshConn := zsshlib.EstablishClient(flags, username, targetIdentity, token)
+		sshConn := zsshlib.EstablishClient(flags, args[0], targetIdentity, token)
 		defer func() { _ = sshConn.Close() }()
 		err = zsshlib.RemoteShell(sshConn, cmdArgs)
 		if err != nil {

--- a/zsshlib/flags.go
+++ b/zsshlib/flags.go
@@ -2,11 +2,10 @@ package zsshlib
 
 import (
 	"fmt"
-	"os"
 	"os/user"
-	"path/filepath"
 	"runtime"
 	"strings"
+	"zssh/config"
 
 	"github.com/sirupsen/logrus"
 	"github.com/spf13/cobra"
@@ -17,6 +16,7 @@ type SshFlags struct {
 	SshKeyPath  string
 	Debug       bool
 	ServiceName string
+	Username    string
 	OIDC        OIDCFlags
 }
 
@@ -34,26 +34,28 @@ type ScpFlags struct {
 }
 
 func (f *SshFlags) GetUserAndIdentity(input string) (string, string) {
-	username := ParseUserName(input)
-	f.DebugLog("      username set to: %s", username)
+	username := ParseUserName(input, true)
 	targetIdentity := ParseTargetIdentity(input)
 	f.DebugLog("targetIdentity set to: %s", targetIdentity)
 	return username, targetIdentity
 }
 
-func ParseUserName(input string) string {
+func ParseUserName(input string, returnDefault bool) string {
 	var username string
 	if strings.ContainsAny(input, "@") {
 		userServiceName := strings.Split(input, "@")
 		username = userServiceName[0]
 	} else {
-		curUser, err := user.Current()
-		if err != nil {
-			logrus.Fatal(err)
-		}
-		username = curUser.Username
-		if strings.Contains(username, "\\") && runtime.GOOS == "windows" {
-			username = strings.Split(username, "\\")[1]
+		if returnDefault {
+
+			curUser, err := user.Current()
+			if err != nil {
+				logrus.Fatal(err)
+			}
+			username = curUser.Username
+			if strings.Contains(username, "\\") && runtime.GOOS == "windows" {
+				username = strings.Split(username, "\\")[1]
+			}
 		}
 	}
 	return username
@@ -87,34 +89,103 @@ func MarkOidcagsRequired(cmd *cobra.Command) {
 
 // TODO: Add config file support
 func (f *SshFlags) OIDCFlags(cmd *cobra.Command, exeName string) {
-	cmd.Flags().StringVarP(&f.OIDC.CallbackPort, "CallbackPort", "p", "63275", "Port for Callback. default: 63275")
-	cmd.Flags().StringVarP(&f.OIDC.ClientID, "ClientID", "n", "cid1", "IdP ClientID. default: cid1")
+	defaults := config.DefaultConfig()
+	cmd.Flags().StringVarP(&f.OIDC.CallbackPort, "CallbackPort", "p", "", "Port for Callback. default: "+defaults.OIDC.CallbackPort)
+	cmd.Flags().StringVarP(&f.OIDC.ClientID, "ClientID", "n", "", "IdP ClientID. default: "+defaults.OIDC.ClientID)
 	cmd.Flags().StringVarP(&f.OIDC.ClientSecret, "ClientSecret", "e", "", "IdP ClientSecret. default: (empty string - use PKCE)")
-	cmd.Flags().StringVarP(&f.OIDC.Issuer, "OIDCIssuer", "a", "https://dev-yourid.okta.com", "URL of the OpenID Connect provider. required")
-	cmd.Flags().BoolVarP(&f.OIDC.Mode, "oidc", "o", false, "toggle OIDC mode. default: false")
+	cmd.Flags().StringVarP(&f.OIDC.Issuer, "OIDCIssuer", "a", "", "URL of the OpenID Connect provider. required")
+	cmd.Flags().BoolVarP(&f.OIDC.Mode, "oidc", "o", false, fmt.Sprintf("toggle OIDC mode. default: %t", defaults.OIDC.Enabled))
 }
 
 func (f *SshFlags) InitFlags(cmd *cobra.Command, exeName string) {
-	cmd.Flags().StringVarP(&f.ServiceName, "service", "s", exeName, fmt.Sprintf("service name. default: %s", exeName))
-	cmd.Flags().StringVarP(&f.ZConfig, "ZConfig", "c", "", fmt.Sprintf("Path to ziti config file. default: $HOME/.ziti/%s.json", f.ServiceName))
+	defaults := config.DefaultConfig()
+	cmd.Flags().StringVarP(&f.ServiceName, "service", "s", "", fmt.Sprintf("service name. default: %s", defaults.Service))
+	cmd.Flags().StringVarP(&f.ZConfig, "ZConfig", "c", "", fmt.Sprintf("Path to ziti config file. default: "+config.DefaultIdentityFile()))
 	cmd.Flags().StringVarP(&f.SshKeyPath, "SshKeyPath", "i", "", "Path to ssh key. default: $HOME/.ssh/id_rsa")
 	cmd.Flags().BoolVarP(&f.Debug, "debug", "d", false, "pass to enable additional debug information")
-
-	if f.SshKeyPath == "" {
-		userHome, err := os.UserHomeDir()
-		if err != nil {
-			logrus.Fatalf("could not find UserHomeDir? %v", err)
+	/*
+		if f.SshKeyPath == "" {
+			userHome, err := os.UserHomeDir()
+			if err != nil {
+				logrus.Fatalf("could not find UserHomeDir? %v", err)
+			}
+			f.SshKeyPath = filepath.Join(userHome, SSH_DIR, ID_RSA)
 		}
-		f.SshKeyPath = filepath.Join(userHome, SSH_DIR, ID_RSA)
-	}
-	f.DebugLog("    flags.SshKeyPath set to: %s", f.SshKeyPath)
+		f.DebugLog("    flags.SshKeyPath set to: %s", f.SshKeyPath)
 
-	if f.ZConfig == "" {
-		userHome, err := os.UserHomeDir()
-		if err != nil {
-			logrus.Fatalf("could not find UserHomeDir? %v", err)
+		if f.ZConfig == "" {
+			userHome, err := os.UserHomeDir()
+			if err != nil {
+				logrus.Fatalf("could not find UserHomeDir? %v", err)
+			}
+			f.ZConfig = filepath.Join(userHome, ".ziti", fmt.Sprintf("%s.json", exeName))
 		}
-		f.ZConfig = filepath.Join(userHome, ".ziti", fmt.Sprintf("%s.json", exeName))
+		f.DebugLog("       ZConfig set to: %s", f.ZConfig)
+	*/
+}
+
+func Combine(cmd *cobra.Command, c *SshFlags, cfg *config.Config) {
+	d := config.DefaultConfig()
+	if c.ZConfig == "" {
+		if cfg.ZConfig == "" {
+			c.ZConfig = d.ZConfig
+		} else {
+			c.ZConfig = cfg.ZConfig
+		}
 	}
-	f.DebugLog("       ZConfig set to: %s", f.ZConfig)
+	if c.SshKeyPath == "" {
+		if cfg.SshKeyPath == "" {
+			c.SshKeyPath = d.SshKeyPath
+		} else {
+			c.SshKeyPath = cfg.SshKeyPath
+		}
+	}
+	if c.ServiceName == "" {
+		c.ServiceName = cfg.Service
+		if cfg.Service == "" {
+			c.ServiceName = d.Service
+		} else {
+			c.ServiceName = cfg.Service
+		}
+	}
+	if c.Username == "" {
+		c.Username = cfg.Username
+		if cfg.Service == "" {
+			c.Username = d.Username
+		} else {
+			c.Username = cfg.Username
+		}
+	}
+	if !cmd.Flags().Changed("oidc") {
+		c.OIDC.Mode = cfg.OIDC.Enabled
+	}
+	if c.OIDC.Mode {
+		if c.OIDC.Issuer == "" {
+			c.OIDC.Issuer = cfg.OIDC.Issuer
+			if cfg.OIDC.Issuer == "" {
+				c.OIDC.Issuer = d.OIDC.Issuer
+			} else {
+				c.OIDC.Issuer = cfg.OIDC.Issuer
+			}
+		}
+		if c.OIDC.CallbackPort == "" {
+			c.OIDC.CallbackPort = cfg.OIDC.CallbackPort
+			if cfg.OIDC.CallbackPort == "" {
+				c.OIDC.CallbackPort = d.OIDC.CallbackPort
+			} else {
+				c.OIDC.CallbackPort = cfg.OIDC.CallbackPort
+			}
+		}
+		if c.OIDC.ClientID == "" {
+			c.OIDC.ClientID = cfg.OIDC.ClientID
+			if cfg.OIDC.ClientID == "" {
+				c.OIDC.ClientID = d.OIDC.ClientID
+			} else {
+				c.OIDC.ClientID = cfg.OIDC.ClientID
+			}
+		}
+		if c.OIDC.ClientSecret == "" {
+			// good
+		}
+	}
 }

--- a/zsshlib/oidc.go
+++ b/zsshlib/oidc.go
@@ -12,7 +12,7 @@ import (
 
 func OIDCFlow(initialContext context.Context, flags SshFlags) (string, error) {
 	callbackPath := "/auth/callback"
-	cfg := &Config{
+	cfg := &OIDCConfig{
 		Config: oauth2.Config{
 			ClientID:     flags.OIDC.ClientID,
 			ClientSecret: flags.OIDC.ClientSecret,


### PR DESCRIPTION
adding config file support. config file would look something like:
```
zsshSvcServer:
  user: ubuntu
  ssh_key_path: /home/cd/.encrypted/.ssh/dovholuknfaws.pem
  zconfig: /home/cd/git/github/openziti-test-kitchen/zssh/zsshSvcClient.json
  service: zsshSvc
  oidc:
    callback_port: "63275"
    client_id: cid1
    client_secret: ""
    issuer: https://keycloak.clint.demo.openziti.org:8446/realms/zitirealm
    enabled: true

zsshSvcServer22:
  zconfig: /home/cd/git/github/openziti-test-kitchen/zssh/zsshSvcClient.json
  service: zssh
```